### PR TITLE
Adding new fields to import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,17 @@ If you do not want to install the app, a hosted version is available: [Clubhouse
 * external_id
 * labels (comma-separated list of the labels to attach)
 * external_links
-* workflow_state _id
-* milestone_id
+* workflow_state_id (number); OR state (name of state in Clubhouse)
 * description
 * estimate
-* owner_ids (Space delimited list of owner UUID)
+* owner_ids (Space delimited list of owner UUID); OR owners (list of owner email addresses)
+* requested_by_id (UUID of user); OR requester (user email address)
+* tasks - any of the following formats should work (with or without line breaks between tasks):
+    * \[&zwnj;&nbsp;&zwnj;\] Task description 1;\[&zwnj;&nbsp;&zwnj;\] Task description 2
+    *  1&zwnj;. Task description; 2. Task description
+    * \* Task description 1 * Task description 2
+    * \- Task description 1 - Task description 2
+    * Task description 1; Task description 2
 
 See a complete <a href="https://clubhouse.io/api/rest/v3/#Stories" target="_blank">list of available fields</a>.
  

--- a/app.php
+++ b/app.php
@@ -42,7 +42,7 @@ if (!empty($_FILES['csv']['name']) && substr($_FILES['csv']['name'], -4) == '.cs
             );
             
             // Optional columns
-            addIfNotEmpty('milestone_id', $line, $payload);
+//            addIfNotEmpty('milestone_id', $line, $payload);
             addIfNotEmpty('description', $line, $payload);
             addIfNotEmpty('estimate', $line, $payload);
             addIfNotEmpty('epic_id', $line, $payload);

--- a/app.php
+++ b/app.php
@@ -47,6 +47,7 @@ if (!empty($_FILES['csv']['name']) && substr($_FILES['csv']['name'], -4) == '.cs
             addIfNotEmpty('estimate', $line, $payload);
             addIfNotEmpty('epic_id', $line, $payload);
             addIfNotEmpty('external_id', $line, $payload);
+            addIfNotEmpty('requested_by_id', $line, $payload);
             addIfNotEmptyAsArray('owner_ids', $line, ' |;|,|\n', $payload);
             addIfNotEmptyAsHash('labels', $line, ';|,|\n', 'name', $payload);
             addIfNotEmptyAsArray('external_links', $line, ' |;|,|\n', $payload);

--- a/app.php
+++ b/app.php
@@ -47,9 +47,9 @@ if (!empty($_FILES['csv']['name']) && substr($_FILES['csv']['name'], -4) == '.cs
             addIfNotEmpty('estimate', $line, $payload);
             addIfNotEmpty('epic_id', $line, $payload);
             addIfNotEmpty('external_id', $line, $payload);
-            addIfNotEmptyAsArray('owner_ids', $line, ' ', $payload);
-            addIfNotEmptyAsHash('labels', $line, ',', 'name', $payload);
-            addIfNotEmptyAsArray('external_links', $line, ' ', $payload);
+            addIfNotEmptyAsArray('owner_ids', $line, ' |;|,|\n', $payload);
+            addIfNotEmptyAsHash('labels', $line, ';|,|\n', 'name', $payload);
+            addIfNotEmptyAsArray('external_links', $line, ' |;|,|\n', $payload);
             addIfNotEmpty('external_id', $line, $payload);
             addIfNotEmpty('workflow_state_id', $line, $payload);
 
@@ -87,8 +87,10 @@ function addIfNotEmpty($key, $src, &$dest) {
   * and add a $key with the array as its value to $dest.
   *
   */
-function addIfNotEmptyAsArray($key, $src, $delim, &$dest) {
-    if (isNotEmptyString($src[$key])) $dest[$key] = explode($delim, $src[$key]);
+function addIfNotEmptyAsArray($key, $src, $delim, &$dest)
+{
+    if (isNotEmptyString($src[$key]))
+        $dest[$key] = preg_split('/ *(' . $delim . ') */', $src[$key]);
 }
 
 /**
@@ -98,10 +100,11 @@ function addIfNotEmptyAsArray($key, $src, $delim, &$dest) {
  * $dest, using $secondkey as the internal key
  *
  */
-function addIfNotEmptyAsHash($key, $src, $delim, $secondkey, &$dest) {
+function addIfNotEmptyAsHash($key, $src, $delim, $secondkey, &$dest)
+{
     if (isNotEmptyString($src[$key])) {
         $hash = array();
-        $values = explode($delim, $src[$key]);
+        $values = preg_split('/ *(' . $delim . ') */', $src[$key]);
         foreach ($values as $item) {
             $hash[] = array($secondkey => $item);
         }

--- a/app.php
+++ b/app.php
@@ -138,7 +138,7 @@ function unpackCsv($csv) {
 
 function postClubhouse($token, $data) {
 
-    $story_url = 'https://api.clubhouse.io/api/v3/stories?token=' . $token;
+    $story_url = 'https://api.clubhouse.io/api/v3/stories';
 
     $ch = curl_init($story_url);
     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
@@ -147,9 +147,10 @@ function postClubhouse($token, $data) {
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
     curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
     curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-        'Accept: application/json',
-        'Content-Type: application/json',
-        'Content-Length: ' . strlen($data))
+            'Accept: application/json',
+            'Content-Type: application/json',
+            'Clubhouse-Token: ' . $token,
+            'Content-Length: ' . strlen($data))
     );
 
     $result = curl_exec($ch);

--- a/index.php
+++ b/index.php
@@ -1,4 +1,4 @@
-<?php require_once('app.php'); ?> 
+<?php require_once('app.php'); ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -22,7 +22,7 @@
         <p>You are free to <a href="https://github.com/mikkelson/clubhouse-csv-import" target="_blank">download the source code</a> for this tool.</p>
       </div>
     </div>
-    
+
     <div class="row">
      <form action="index.php#resultContent" method="post" enctype="multipart/form-data">
       <input type='text' name='token' placeholder='Clubhouse API Token' required="required" value="<?=@$_POST['token'];?>"/>
@@ -37,7 +37,7 @@
     <div class="row">
       <div class="column" style="margin-top: 5%">
         <h5>Results:</h5>
-        
+
         <?php if(!empty($skipped)){?>
             <?=$skipped;?> of a total <?=$total;?> csv lines skipped because of missing required fields.
         <?php }?>
@@ -45,7 +45,7 @@
         <?php foreach($counts as $label => $c){?>
             <br /><?=$c;?> <?=$label;?>(s) imported successfully.
         <?php }?>
-  
+
 
         <?php if(!empty($error_lines)){?>
             <br />The following <strong><?=$failed;?> CSV lines failed:</strong>
@@ -64,7 +64,7 @@
     <div class="row">
         <div class="column" style="margin-top: 5%">
             <h5>CSV Fields</h5>
-            <p>Line 1 of your CSV must contain the field name(s) as below. <br/>The order of fields is not important. 
+            <p>Line 1 of your CSV must contain the field name(s) as below. <br/>The order of fields is not important.
             <a href="example.csv">Download example.csv</a></p>
             <ul>
               <li>
@@ -78,15 +78,25 @@
               <li>
                 Optional Fields
                 <ul>
-                	<li>epic_id</li>
+                    <li>epic_id <em>(must be a pre-existing Epic)</em></li>
                 	<li>external_id</li>
                 	<li>labels</li>
                 	<li>external_links</li>
-                	<li>workflow_state_id</li>
-                    <li>milestone_id</li>
+                    <li>workflow_state_id <em>(number)</em>; OR state <em>(name of state in Clubhouse)</em></li>
                     <li>description</li>
                     <li>estimate</li>
-                    <li>owner_ids <em>(Space delimitted list of owner UUID)</em></li>
+                    <li>owner_ids <em>(Space delimitted list of owner UUID)</em>; OR owners <em>(list of owner email addresses)</em></li>
+                    <li>requested_by_id <em>(UUID of user)</em>; OR requester <em>(user email address)</em></li>
+                    <li>requested_by_id <em>(UUID of user)</em>; OR requester <em>(user email address)</em></li>
+                    <li>tasks - any of the following formats should work (with or without line breaks between tasks):
+                        <ul>
+                            <li>[ ] Task description 1;[ ] Task description 2</li>
+                            <li>1. Task description; 2. Task description</li>
+                            <li>* Task description 1 * Task description 2</li>
+                            <li>- Task description 1 - Task description 2</li>
+                            <li>Task description 1; - Task description 2</li>
+                        </ul>
+                    </li>
                     <li><em>See a complete <a href="https://clubhouse.io/api/rest/v3/#Stories" target="_blank">list of available fields</a>.</em></li>
                 </ul>
               </li>
@@ -99,7 +109,7 @@
         <p>Feedback and bug reports welcome <a href="https://twitter.com/happyrailfail" target="_blank">@happyrailfail</a>.</p>
       </div>
     </div>
-    
+
   </div>
 <a href="https://github.com/mikkelson/clubhouse-csv-import" class="github-corner" aria-label="View source on Github"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#FD6C6C; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
 </body>


### PR DESCRIPTION
Added some new fields after finding out a straight export->reimport didn't work as intended:
- requested_by_id (UUID of the user)
- tasks (delimited list of tasks, formats in README, first format matches how Clubhouse exports this field)
- owners (delimited list of user emails, Clubhouse exports this instead of UUID's)
- requester (user email address, Clubjouse exports this instead of UUID)
- state (workflow state name as displayed in Clubhouse, exports this instead of ID)

Also removed milestone_id as this was failing (it's still in the spec, but if it's provided Clubhouse fails the import)

Also allowed delimited fields to use different delimiters, as some used spaces and some used commas, and users may get confused or use a different delimiter and it seemed unnecessary to pin down to just one (especially inconsistently), or the API might update again and change how the export is formatted. They should now all delimit on commas, spaces (except labels, since they can contain spaces as part of the label), semicolons, or new lines.